### PR TITLE
let go build know that your are using netgo since it exported externally

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -1,4 +1,5 @@
-GOOS=linux GOARCH=386 go build -ldflags "-linkmode external -extldflags -static" -o AAH-linux-386
-GOOS=linux GOARCH=amd64 go build -ldflags "-linkmode external -extldflags -static" -o AAH-linux-amd64
-GOOS=linux GOARCH=arm go build -ldflags "-linkmode external -extldflags -static" -o AAH-linux-arm
-GOOS=linux GOARCH=arm64 go build -ldflags "-linkmode external -extldflags -static" -o AAH-linux-arm64
+GOOS=linux GOARCH=386 go build -ldflags "-linkmode external -extldflags -static" -a -tags netgo -installsuffix netgo -o AAH-linux-386
+GOOS=linux GOARCH=amd64 go build -ldflags "-linkmode external -extldflags -static" -a -tags netgo -installsuffix netgo -o AAH-linux-amd64
+GOOS=linux GOARCH=arm go build -ldflags "-linkmode external -extldflags -static" -a -tags netgo -installsuffix netgo -o AAH-linux-arm
+GOOS=linux GOARCH=arm64 go build -ldflags "-linkmode external -extldflags -static" -a -tags netgo -installsuffix netgo -o AAH-linux-arm64
+


### PR DESCRIPTION
Saw your tweet, let your binary know that it is packaging network library with it. Until Go <1.5 it wasn't required.